### PR TITLE
Remove unnecessary parameter FORCE_MTLS

### DIFF
--- a/etc/device-vendor.properties
+++ b/etc/device-vendor.properties
@@ -8,4 +8,3 @@ FRIENDLY_ID=RDKERPi4
 COMMUNITY_BUILDS=true
 # RDKFWUpgrader required properties
 DIFW_PATH=/opt/ota-dlpath/
-FORCE_MTLS=0


### PR DESCRIPTION
As per component owner; this should be a build time check instead of runtime considering the proposed security refactoring of MTLS logic. https://github.com/rdkcentral/rdkfwupdater/pull/6 has the required work-around to address this.