### PR TITLE
RDKVREFPLT-5430: add systemd dropins for display related sequencing

### DIFF
--- a/systemd_units/00-dsmgr-vendor.conf
+++ b/systemd_units/00-dsmgr-vendor.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=wpeframework-rdkshell.service
+Requires=wpeframework-rdkshell.service

--- a/systemd_units/00-wpeframework-rdkshell-vendor.conf
+++ b/systemd_units/00-wpeframework-rdkshell-vendor.conf
@@ -1,0 +1,5 @@
+[Unit]
+Requires=
+After=
+Requires=wpeframework.service iarmbusd.service
+After=wpeframework.service iarmbusd.service


### PR DESCRIPTION
Reason for Change: In RPI DSHAL westeros-gl-console utility is used to change GL settings which requires westeros server to be running. RDKShell plugin starts westeros server instance.