### PR TITLE
Revert "RDKVREFPLT-5430: add systemd dropins for display related sequencing"

### DIFF
--- a/systemd_units/00-dsmgr-vendor.conf
+++ b/systemd_units/00-dsmgr-vendor.conf
@@ -1,3 +1,0 @@
-[Unit]
-After=wpeframework-rdkshell.service
-Requires=wpeframework-rdkshell.service

--- a/systemd_units/00-wpeframework-rdkshell-vendor.conf
+++ b/systemd_units/00-wpeframework-rdkshell-vendor.conf
@@ -1,5 +1,0 @@
-[Unit]
-Requires=
-After=
-Requires=wpeframework.service iarmbusd.service
-After=wpeframework.service iarmbusd.service


### PR DESCRIPTION
Reason for Change: Reverts rdkcentral/rdkvhal-sysint-raspberrypi4#31
Drop-in cannot override `After` and `Requires` section.