### PR TITLE
RDKVREFPLT-5789: Make oem-first-boot.service dependencies correct

### DIFF
--- a/systemd_units/oem-first-boot.service
+++ b/systemd_units/oem-first-boot.service
@@ -18,7 +18,8 @@
 ##########################################################################
 [Unit]
 Description=OEM first boot status updation service
-After=multi-user.target
+Before=multi-user.target
+After=local-fs.target remote-fs.target
 ConditionPathExists=!/opt/persistent/first-boot-done
 
 [Service]


### PR DESCRIPTION
Reason for Change: Make oem-first-boot.service after FS mounts and before multi-user.target since it only needs mount related activities.